### PR TITLE
add dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/github.com/bmizerany/assert"]
+	path = vendor/github.com/bmizerany/assert
+	url = https://github.com/bmizerany/assert


### PR DESCRIPTION
@f2prateek 

analytics-go depends on this package, but the migration away from godep has broken the recursive tests command we use (`go test ./...`) because it goes into the vendor directory and tries to execute tests for dependencies but the github.com/bmizerany/assert package was missing.

Please take a look and let me know if this is good to merge.
